### PR TITLE
Amend DSA website from "International Dance" to "Modern Dance"

### DIFF
--- a/_admissions/Direct School Admission.md
+++ b/_admissions/Direct School Admission.md
@@ -12,7 +12,7 @@ Secondary School before the Secondary One Posting Exercise.</p>
 <h4>Admission Criteria</h4>
 <p>We invite pupils who fulfill any of the admission criteria mentioned below
 to apply:</p>
-<p><strong>Category 1: Performing Arts - Band, Choir, International Dance, Indian Dance, Drama</strong>
+<p><strong>Category 1: Performing Arts - Band, Choir, Modern Dance, Indian Dance, Drama</strong>
 </p>
 <ul>
 <li>


### PR DESCRIPTION
MOEHQ requested for CWSS to use "Modern Dance" instead of "International Dance" in order to align with national nomenclature.