### PR TITLE
Update Sec 1 transfer appeal page to include COPs

### DIFF
--- a/_2025-secondary-1-registration/School Transfer Procedures.md
+++ b/_2025-secondary-1-registration/School Transfer Procedures.md
@@ -21,9 +21,8 @@ contact the school’s General Office at 6560-6866.</p>
 <p><strong>Students posted other schools but wish to transfer to Commonwealth Secondary (CWSS)</strong>
 </p>
 <p></p>
-<p>Please note that appellants are required to meet the cut-off points for
-the relevant Posting Group in order for their appeal for transfer to be
-considered.</p>
+<p>Please note that appellants must meet the cut-off points for the relevant
+Posting Group in order for their appeal to be eligible for consideration.</p>
 <p></p>
 <table style="minWidth: 100px">
 <colgroup>

--- a/_2025-secondary-1-registration/School Transfer Procedures.md
+++ b/_2025-secondary-1-registration/School Transfer Procedures.md
@@ -23,11 +23,50 @@ contact the school’s General Office at 6560-6866.</p>
 <p></p>
 <p>Please note that appellants are required to meet the cut-off points for
 the relevant Posting Group in order for their appeal for transfer to be
-considered. Please submit the below appeal form via email to <a href="mailto:cwss@moe.edu.sg" rel="noopener noreferrer nofollow" target="_blank">cwss@moe.edu.sg</a> &nbsp;<strong><u>OR</u></strong> &nbsp;
-<a href="https://go.gov.sg/psle-to-s1-2025-posting-appeal-form" rel="noopener noreferrer nofollow" target="_blank">https://go.gov.sg/psle-to-s1-2025-posting-appeal-form</a>&nbsp; <strong>By 27 Dec 2024.</strong>
+considered.</p>
+<p></p>
+<table style="minWidth: 100px">
+<colgroup>
+<col>
+<col>
+<col>
+<col>
+</colgroup>
+<tbody>
+<tr>
+<th rowspan="1" colspan="1">
+<p>Posting Group</p>
+</th>
+<th rowspan="1" colspan="1">
+<p>PG3</p>
+</th>
+<th rowspan="1" colspan="1">
+<p>PG2</p>
+</th>
+<th rowspan="1" colspan="1">
+<p>PG1</p>
+</th>
+</tr>
+<tr>
+<td rowspan="1" colspan="1">
+<p><strong>Cut-off Point for 2025 Sec 1 Intake</strong>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>12</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>23</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>27</p>
+</td>
+</tr>
+</tbody>
+</table>
+<p></p>
+<p>Please submit the below appeal form via this online form <a href="https://go.gov.sg/psle-to-s1-2025-posting-appeal-form" rel="noopener noreferrer nofollow" target="_blank">https://go.gov.sg/psle-to-s1-2025-posting-appeal-form</a> by<strong> 27 Dec 2024.</strong>
 </p>
 </li>
 </ul>
-<p><a href="/files/2025 Sec 1 Registration/12_CWSS_Sec_1_Appeal_Form_2025.pdf" rel="noopener nofollow" target="_blank">Click here for Appeal Form</a>
-</p>
 <p></p>

--- a/_2025-secondary-1-registration/School Transfer Procedures.md
+++ b/_2025-secondary-1-registration/School Transfer Procedures.md
@@ -65,7 +65,8 @@ considered.</p>
 </tbody>
 </table>
 <p></p>
-<p>Please submit the below appeal form via this online form <a href="https://go.gov.sg/psle-to-s1-2025-posting-appeal-form" rel="noopener noreferrer nofollow" target="_blank">https://go.gov.sg/psle-to-s1-2025-posting-appeal-form</a> by<strong> 27 Dec 2024.</strong>
+<p>If you wish to appeal for a transfer to CWSS, please submit this online
+form <a href="https://go.gov.sg/psle-to-s1-2025-posting-appeal-form" rel="noopener noreferrer nofollow" target="_blank">https://go.gov.sg/psle-to-s1-2025-posting-appeal-form</a> by<strong> 27 Dec 2024.</strong>
 </p>
 </li>
 </ul>


### PR DESCRIPTION
Please publish only after 18 December 0900hr. The page has been updated to inform appellants about the relevant COPs for each Posting Group, so as to turn away ineligible appellants. The appeal channel is also limited to the FormSG to avoid overwhelming the very busy generic email channel.